### PR TITLE
feat: Allow BrowserRouter "basename" to be passed in as configuration

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,6 +24,7 @@ import SystemRoutes from "./components/system/Routes";
 import KeyboardShortcuts from "./components/support/KeyboardShortcuts";
 import OrganisationRoutes from "./components/organisation/Routes";
 import CommandsRoutes from 'components/commands/Routes';
+import Configuration from './Configuration';
 
 const App = () => {
     const [theme, setTheme] = useState(localStorage.getItem('theme') || 'dark')
@@ -33,7 +34,7 @@ const App = () => {
     }, [theme])
 
     return (
-        <Router>
+        <Router basename={Configuration.appBasename}>
             <AuthProvider>
                 <ThemeContext.Provider value={{ theme, setTheme }}>
                     <Switch>

--- a/src/Configuration.js
+++ b/src/Configuration.js
@@ -1,6 +1,7 @@
 const Configuration = {
     apiEndpoint: window.env.REACT_APP_API_ENDPOINT,
     wsEndpoint: window.env.REACT_APP_WS_ENDPOINT,
+    appBasename: window.env.REACT_APP_BASENAME || '/',
 };
 
 export default Configuration;


### PR DESCRIPTION
REACT_APP_BASENAME will be based to BrowserRouter as "basename".
If given, all application routes will be prefixed with given value, otherwise '/'.

This feature allows Reconmap Web Client to be deployed to a "subdirectory"
(e.g. https://somehost.com/reconmap/) and closes #68 .