### PR TITLE
fix: redirect on session reset

### DIFF
--- a/environment.local.js
+++ b/environment.local.js
@@ -3,5 +3,8 @@ window.env = {
     REACT_APP_API_ENDPOINT: 'http://localhost:8080',
 
 	// URL to the Reconmap WebSocket API including protocol and port but not trailing slash
-    REACT_APP_WS_ENDPOINT: 'ws://localhost:8765'
+    REACT_APP_WS_ENDPOINT: 'ws://localhost:8765',
+
+    // Application base path e.g. https://somehost.com/reconmap
+    // REACT_APP_BASENAME: '/reconmap'
 };

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -5,8 +5,9 @@ import NotificationsBadge from '../badges/NotificationsBadge';
 import SearchBox from "../search/Box";
 import LinkButton from '../ui/buttons/Link';
 import HeaderUserMenu from '../ui/HeaderUserMenu';
+import Configuration from '../../Configuration';
 import './Header.scss';
-
+import * as path from 'path';
 
 const LINKS = [
     { title: "User Manual", to: { pathname: UserManualUrl } },
@@ -21,7 +22,7 @@ export default function Header() {
                 <nav>
                     <Link to='/' style={{ cursor: 'pointer' }} className='logo'>
                         <h3>
-                            <img alt='logo' src="/logo.svg" />
+                            <img alt='logo' src={ path.join(Configuration.appBasename, 'logo.svg') } />
                             <strong style={{ color: 'var(--white)' }} className='from-tablet'>
                                 Recon<span style={{ color: 'var(--primary-color)' }}>map</span>
                             </strong>

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -5,7 +5,7 @@ import Auth from "./auth";
 
 function resetSessionStorageAndRedirect() {
     Auth.removeSession();
-    window.location = '/';
+    window.location = Configuration.appBasename;
 }
 
 function secureApiFetch(url, init) {


### PR DESCRIPTION
* Redirect to `REACT_APP_BASENAME` instead of hardcoded `/`.
* `REACT_APP_BASENAME` example added to the configuration example file
* logo URL fixed when `REACT_APP_BASENAME` is defined.
