### PR TITLE
An external ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ environment.js
 tags
 tags.*
 .config
+*.code-workspace

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,15 @@ DOCKER_IMAGE_NAME = quay.io/reconmap/web-client
 DOCKER_CONTAINER_NAME = reconmap-web-client
 DOCKER_DEV_TAG = reconmap/web-client:dev
 
-HOST_UID=$(shell id -u)
-HOST_GID=$(shell id -g)
+# macOS is using different IDs than linux
+UNAME=$(shell uname)
+ifeq ($(UNAME),Darwin)
+	HOST_UID=1000
+	HOST_GID=1000
+else
+	HOST_UID=$(shell id -u)
+	HOST_GID=$(shell id -g)
+endif
 CONTAINER_UID_GID=$(HOST_UID):$(HOST_GID)
 
 ifdef TRAVIS_BRANCH

--- a/src/components/projects/DetailsTab.js
+++ b/src/components/projects/DetailsTab.js
@@ -35,6 +35,11 @@ const ProjectDetailsTab = ({ project }) => {
 
                 <dt>Description</dt>
                 <dd>{project.description ? <ReactMarkdown>{project.description}</ReactMarkdown> : <EmptyField />}</dd>
+
+                {!isTemplate && <>
+                    <dt>External ID</dt>
+                    <dd>{project.external_id}</dd>
+                </>}
             </dl>
 
             <h4 style={{ marginTop: 20 }}>

--- a/src/components/projects/Form.js
+++ b/src/components/projects/Form.js
@@ -47,6 +47,10 @@ const ProjectForm = ({ isEdit = false, project, projectSetter: setProject, onFor
                         )}
                     </Select>
                 </label>
+
+                <label>External ID
+                    <input type="text" name="external_id" onChange={handleFormChange} value={project.external_id || ""} required autoFocus />
+                </label>
             </>}
 
             <label>Name


### PR DESCRIPTION
## Description
This small change adds a new field named 'external ID' into the Project. It provides an opportunity to link the report with the external evidence of realised projects. Since this field is intended to be unique for each project, I did not add it to the Project templates.

## Examples

### Create and edit project
![project](https://user-images.githubusercontent.com/2551605/151332981-47d77208-3e83-4227-93e3-37efdeca7034.gif)

### Create report
![report](https://user-images.githubusercontent.com/2551605/151333027-6ec981fb-1d6e-47f7-a88b-da91cf40ab8c.gif)


