### PR TITLE
[Fix] Owasp did not re-compute values correctly

### DIFF
--- a/src/components/vulnerabilities/OwaspRR.js
+++ b/src/components/vulnerabilities/OwaspRR.js
@@ -71,22 +71,24 @@ const OwaspRR = ({
 
     const computeLikehood = (fields) => {
         let sum = 0;
-        Object.entries(fields).forEach(([key, value]) => {
+        fields.map(([key, value]) => {
             if ((key === 'SL') || (key === 'M') || (key === 'O') || (key === 'S')
                 || (key === 'ED') || (key === 'EE') || (key === 'A') || (key === 'ID')) {
                 sum += parseInt(value);
             }
+            return sum;
         });
         return sum / 8;
     }
 
     const computeImpact = (fields) => {
         let sum = 0;
-        Object.entries(fields).forEach(([key, value]) => {
+        fields.map(([key, value]) => {
             if ((key === 'LC') || (key === 'LI') || (key === 'LAV') || (key === 'LAC')
                 || (key === 'FD') || (key === 'RD') || (key === 'NC') || (key === 'PV')) {
                 sum += parseInt(value);
             }
+            return sum;
         });
         return sum / 8;
     }
@@ -170,10 +172,11 @@ const OwaspRR = ({
             return newValue;
         }
         let temp = 0;
-        Object.entries(fields).forEach(([key, value]) => {
+        fields.map(([key, value]) => {
             if (key === name) {
                 temp = value;
             }
+            return temp;
         });
 
         return temp;


### PR DESCRIPTION
The original implementation produced warnings during compilation. We removed the these warnings by commit `f2013271a2462df913a730fad3b66003503122b9`.

But it for some reason broke the computation. The vector was not correctly parsed and updates of particular values were extremely unstable - sometimes such change was propagated to chart and vector, but in the most cases it did not work at all. 
Therefore, I returned it back to use `map` method, but I also added a dummy returns (the result values are not used at all), so there are no warnings during build.