### PR TITLE
[Suggestion] Owasp categories

### DIFF
--- a/src/components/vulnerabilities/Form.js
+++ b/src/components/vulnerabilities/Form.js
@@ -142,12 +142,12 @@ const VulnerabilityForm = ({
                     .then(json => {
                         setSubCategories(json);
                     })
-                setVulnerability({ ...vulnerability, ['parent_category_id']: value, [name]: value });
+                setVulnerability({ ...vulnerability, 'parent_category_id': value, [name]: value });
             } else {
-                setVulnerability({ ...vulnerability, ['category_id']: null });
+                setVulnerability({ ...vulnerability, 'category_id': null });
             }
         } else if ('subcategory_id' === name) {
-            setVulnerability({ ...vulnerability, ['category_id']: value });
+            setVulnerability({ ...vulnerability, 'category_id': value });
         } else {
             setVulnerability({ ...vulnerability, [name]: value });
         }

--- a/src/components/vulnerabilities/categories/List.js
+++ b/src/components/vulnerabilities/categories/List.js
@@ -16,9 +16,9 @@ import VulnerabilityCategoryAddModalDialog from './AddModalDialog';
 import VulnerabilityCategoryEditModalDialog from './EditModalDialog';
 
 const VulnerabilityCategoriesPage = () => {
-    const [categories, fetchCategories] = useFetch('/vulnerabilities/categories')
-
-    const destroy = useDelete('/vulnerabilities/categories/', fetchCategories);
+    const [categories, fetchParentCategories] = useFetch('/vulnerabilities/categories?parentsOnly=0')
+    
+    const destroy = useDelete('/vulnerabilities/categories/', fetchParentCategories);
 
     const [editCategory, setEditCategory] = useState({});
 
@@ -26,7 +26,7 @@ const VulnerabilityCategoriesPage = () => {
     const { isOpen: isEditCategoryDialogOpen, onOpen: openEditCategoryDialog, onClose: closeEditCategoryDialog } = useDisclosure();
 
     const onCategoryDialogClosed = () => {
-        fetchCategories();
+        fetchParentCategories();
 
         closeAddCategoryDialog();
         closeEditCategoryDialog();


### PR DESCRIPTION
I've updated the way how categories are treated.
The main goal was to include OWASP WSTG subcategories, which results in really huge list of categories. When the team is using several methodologies, it would be hard to get oriented in the lists. (E.g. when not only WSTG but also MSTG is used).

So, when a new vulnerability is created (or edited), I am using at first parent category, to make the list shorter. 

The behavior looks like this:

https://user-images.githubusercontent.com/2551605/158909391-6e3c8c1f-1aa9-4bcd-824e-44288bea8651.mov

Related PR:
https://github.com/reconmap/rest-api/pull/40
